### PR TITLE
Optimize .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -2,7 +2,6 @@ typeset -x ZPLUG_HOME=$ZDOTDIR/zplug
 
 source $ZPLUG_HOME/init.zsh
 
-zplug "rupa/z", use:z.sh, at:v1.9
 zplug "zsh-users/zsh-completions", at:0.22.0
 zplug "zsh-users/zsh-syntax-highlighting", at:0.5.0, defer:2
 zplug "marzocchi/zsh-notify", at:v1.0
@@ -20,11 +19,6 @@ autoload -Uz add-zsh-hook
 
 export LANG=ja_JP.UTF-8
 export PATH=/usr/local/bin:/usr/local/sbin:/sbin:$PATH
-
-# http://d.hatena.ne.jp/naoya/20130108/1357630895
-function precmd () {
-   z --add "$(pwd -P)"
-}
 
 bindkey -e
 

--- a/.zshrc
+++ b/.zshrc
@@ -109,7 +109,7 @@ REPORTTIME=3
 if [[ -d $HOME/.anyenv ]]; then
     export PATH=~/.anyenv/bin:$PATH
     export PATH=~/.anyenv/shims:$PATH
-    eval "$(anyenv init - zsh)"
+    eval "$(anyenv init - --no-rehash zsh)"
 
     # http://qiita.com/luckypool/items/f1e756e9d3e9786ad9ea
     for D in `ls $HOME/.anyenv/envs`

--- a/.zshrc
+++ b/.zshrc
@@ -154,7 +154,7 @@ function tmux-show-pwd() {
 add-zsh-hook precmd tmux-show-pwd
 
 # configure completion again after all other files are loaded
-zplug load --verbose
+zplug load
 
 # completion alias
 compdef mosh=ssh

--- a/.zshrc
+++ b/.zshrc
@@ -11,8 +11,6 @@ if ! zplug check --verbose; then
   echo; zplug install
 fi
 
-zplug load --verbose
-
 fpath=("$ZPLUG_HOME/repos/zsh-users/zsh-completions/src/" $fpath)
 
 autoload colors
@@ -156,8 +154,7 @@ function tmux-show-pwd() {
 add-zsh-hook precmd tmux-show-pwd
 
 # configure completion again after all other files are loaded
-autoload -Uz compinit
-compinit
+zplug load --verbose
 
 # completion alias
 compdef mosh=ssh

--- a/.zshrc
+++ b/.zshrc
@@ -156,7 +156,6 @@ function tmux-show-pwd() {
 add-zsh-hook precmd tmux-show-pwd
 
 # configure completion again after all other files are loaded
-rm -rf $ZDOTDIR/.zcompdump
 autoload -Uz compinit
 compinit
 

--- a/.zshrc.function
+++ b/.zshrc.function
@@ -1,6 +1,6 @@
 # -*- mode: sh -*-
 
-### cd to the top level of git project ###
+# cd to the top level of git project
 function cdtop() {
     if git rev-parse --is-inside-work-tree > /dev/null; then
         cd `git rev-parse --show-toplevel`
@@ -19,35 +19,8 @@ function e {
     eval "emacsclient -n $args"
 }
 
-function ec2info {
-    aws ec2 describe-instances --instance-ids $1 | jq '.Reservations[].Instances[] | .NetworkInterfaces[].PrivateIpAddresses[], .Tags[]'
-}
-
-function linecount {
-    find . -name "$1" | xargs wc -l
-}
-alias linecount='noglob linecount'
-
 function ng {
   git --no-pager $@
-}
-
-function nsum {
-    ruby -e 'puts ARGV.inject(0) { |sum, num| sum += num.to_i; sum }'
-}
-
-function rep {
-    if [[ $# -lt 2 ]]; then
-        echo "Usage: rep <rep number> <command>"
-        return 1
-    fi
-
-    local rep_count=$1
-    shift
-
-    for i in `seq $rep_count`; do
-        zsh -c $@
-    done
 }
 
 function server() {

--- a/.zshrc.peco
+++ b/.zshrc.peco
@@ -32,10 +32,6 @@ function peco-proc () {
 zle -N peco-proc
 bindkey "^X^P" peco-proc
 
-function findmemo () {
-    ag --ignore "*.pdf" -l -i $1 ~/Dropbox/memo ~/Dropbox/junk | peco | xargs less
-}
-
 function ghis() {
     ghi show $(ghi list --sort updated | grep -v 'open issue' | grep -v 'Not Found' | peco | awk '{ print $1 }')
 }

--- a/.zshrc.peco
+++ b/.zshrc.peco
@@ -21,22 +21,6 @@ function peco-src () {
 zle -N peco-src
 bindkey "^W" peco-src
 
-function peco_select_directory() {
-    local tac
-    if which tac > /dev/null; then
-        tac="tac"
-    else
-        tac="tail -r"
-    fi
-    local dest=$(_z -r 2>&1 | eval $tac | peco --query "$LBUFFER" | awk '{ print $2 }')
-    if [ -n "${dest}" ]; then
-        cd ${dest}
-    fi
-    zle reset-prompt
-}
-zle -N peco_select_directory
-bindkey "^X^J" peco_select_directory
-
 # http://blog.horimisli.me/entry/terminal-env-2014
 function peco-proc () {
     local selected_pid=$(ps ax -o pid,lstart,command | peco --query "$LBUFFER" | awk '{print $1}')

--- a/.zshrc.prompt
+++ b/.zshrc.prompt
@@ -94,15 +94,3 @@ setopt prompt_subst
 PROMPT="%{${fg[magenta]}%}%n ${fg[yellow]}%}%(5~,%-2~/.../%2~,%~) ${fg[white]}%}[%D{%y-%m-%d %T}]%{${reset_color}%} `rprompt-node-version` `rprompt-ruby-version` `rprompt-git-current-branch``rprompt-git-not-pushed``rprompt-git-stash`
 $ "
 PROMPT2='[%n]> '
-
-case "${TERM}" in
-    kterm*|xterm)
-	precmd(){
-	    echo -ne "\033]0;${USER}@${HOST%%.*}:${PWD}\007"
-	}
-	;;
-    dumb | emacs)
-	PROMPT="%m:%~> "
-	unsetopt zle
-	;;
-esac


### PR DESCRIPTION
## WHY

Current loading time of `.zshrc` is too long.

```bash
$ time ( zsh -i -c exit )
[zplug] Loaded from cache (/Users/dtan4/.zsh/zplug/.cache)
 Load "~/.zsh/zplug/repos/rupa/z/z.sh" (rupa/z)
 Load "~/.zsh/zplug/repos/marzocchi/zsh-notify/notify.plugin.zsh" (marzocchi/zsh-notify)
 Load "~/.zsh/zplug/repos/zsh-users/zsh-completions/zsh-completions.plugin.zsh" (zsh-users/zsh-completions)
[zplug] Run compinit
 Load "~/.zsh/zplug/repos/zsh-users/zsh-syntax-highlighting/zsh-syntax-highlighting.plugin.zsh" (zsh-users/zsh-syntax-highlighting)
( zsh -i -c exit; )  1.84s user 1.30s system 98% cpu 3.201 total
```

## WHAT

Speed up 💨 

## REF

- [zshの起動が遅いのでなんとかしたい - Qiita](http://qiita.com/vintersnow/items/7343b9bf60ea468a4180)
- [オレオレ rbenv 運用 Tips - Qiita](http://qiita.com/sonots/items/a309520b9cce1b7631a5)
